### PR TITLE
feat: 画像検索をBing Image Search APIに移行

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ AI_BASE_URL=https://api.x.ai/v1
 
 # Perplexity（/search コマンドを使う場合のみ）
 # PERPLEXITY_API_KEY=your_perplexity_api_key_here
+
+# Bing Image Search（/image コマンドを使う場合のみ）
+# BING_IMAGE_SEARCH_API_KEY=your_bing_image_search_api_key_here

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ xAI GrokとPerplexityを統合したDiscordボットです。サーバー内でA
 
 - **AIチャット**: メンションまたは `/talk` コマンドでAIアシスタントと会話
 - **Web検索**: `/search` コマンドでPerplexity APIを使用したWeb検索と要約（オプション）
+- **画像検索**: `/image` コマンドでBing Image Search APIを使用した画像検索（オプション）
 - **ランダムコマンド**: `/r` で数字のランダム生成、`/r_sma` でスマブラキャラクター選択
 - **犬画像取得**: `/dog` でランダムな犬の画像を取得
 
@@ -15,6 +16,7 @@ xAI GrokとPerplexityを統合したDiscordボットです。サーバー内でA
 - Discord Bot Token
 - xAI API Key
 - Perplexity API Key（`/search` コマンドを使う場合）
+- Bing Image Search API Key（`/image` コマンドを使う場合）
 
 ## セットアップ
 
@@ -26,6 +28,7 @@ xAI GrokとPerplexityを統合したDiscordボットです。サーバー内でA
 BOT_TOKEN=your_discord_bot_token_here
 XAI_API_KEY=your_xai_api_key_here
 PERPLEXITY_API_KEY=your_perplexity_api_key_here  # オプション
+BING_IMAGE_SEARCH_API_KEY=your_bing_image_search_api_key_here  # オプション
 ```
 
 #### 各APIキーの取得方法
@@ -33,6 +36,7 @@ PERPLEXITY_API_KEY=your_perplexity_api_key_here  # オプション
 - **Discord Bot Token**: [Discord Developer Portal](https://discord.com/developers/applications) でアプリケーションを作成し、Botトークンを取得
 - **xAI API Key**: [xAI Console](https://console.x.ai/) で取得
 - **Perplexity API Key**: [Perplexity API](https://www.perplexity.ai/) で取得
+- **Bing Image Search API Key**: [Azure Portal](https://portal.azure.com/) でBing Search v7リソースを作成して取得（月1,000リクエストまで無料）
 
 ### Docker で起動（推奨）
 
@@ -57,6 +61,7 @@ python main.py
 |---------|------|--------|
 | `/talk <message>` | AIアシスタントと会話 | `/talk こんにちは` |
 | `/search <query>` | Webを検索して要約 | `/search Python 最新情報` |
+| `/image <query>` | 画像を検索 | `/image 猫` |
 | `/r <num>` | 1からnumまでのランダムな整数を生成 | `/r 100` |
 | `/r_sma` | スマブラSPのキャラクターをランダムに選択 | `/r_sma` |
 | `/dog` | ランダムな犬の画像を取得 | `/dog` |

--- a/api.py
+++ b/api.py
@@ -1,8 +1,11 @@
+import os
 import requests
 import json
 from utils.logger import setup_logger
 
 logger = setup_logger(__name__)
+
+BING_IMAGE_SEARCH_ENDPOINT = "https://api.bing.microsoft.com/v7.0/images/search"
 
 
 class API:
@@ -27,3 +30,26 @@ class API:
         else:
             logger.warning("[API] dog API: レスポンスが空です")
             return "取得できなかった"
+
+    def image_search(self, query, count=1):
+        api_key = os.getenv("BING_IMAGE_SEARCH_API_KEY")
+        if not api_key:
+            logger.warning("[API] BING_IMAGE_SEARCH_API_KEY が設定されていません")
+            return None
+
+        headers = {"Ocp-Apim-Subscription-Key": api_key}
+        params = {"q": query, "count": count, "safeSearch": "Moderate"}
+
+        try:
+            session = requests.Session()
+            response = session.get(
+                BING_IMAGE_SEARCH_ENDPOINT, headers=headers, params=params)
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            logger.error(
+                f"[API] Bing Image Search failed for query={query}: {e}")
+            return None
+        response.close()
+        logger.debug(
+            f"[API] Bing Image Search {query} -> {response.status_code}")
+        return response.json().get("value", [])

--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ import api
 from ai import AIManager, AIError
 import traceback
 import random
-from ddgs import DDGS
 
 import sys
 import logging
@@ -168,17 +167,25 @@ async def image(interaction: discord.Interaction, query: str):
     await interaction.response.defer(thinking=True)
 
     try:
-        with DDGS() as ddgs:
-            results = list(ddgs.images(query, max_results=1))
+        results = API.image_search(query)
+
+        if results is None:
+            await interaction.followup.send(
+                f"> {query}",
+                embed=discord.Embed(
+                    title="検索エラー", description="画像検索機能が利用できません。", color=0xff0000)
+            )
+            return
 
         if not results:
             await interaction.followup.send(f"> {query}\n\n画像が見つかりませんでした。")
             return
 
         img = results[0]
-        embed = discord.Embed(title=img.get("title", query), color=0x5865F2)
-        embed.set_image(url=img["image"])
-        embed.set_footer(text=f"検索: {query} | 出典: {img.get('source', '')}")
+        embed = discord.Embed(title=img.get("name", query), color=0x5865F2)
+        embed.set_image(url=img["contentUrl"])
+        embed.set_footer(
+            text=f"検索: {query} | 出典: {img.get('hostPageDisplayUrl', '')}")
         await interaction.followup.send(f"> {query}", embed=embed)
 
     except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 discord.py
 openai
 requests
-ddgs


### PR DESCRIPTION
## 概要
`/image` コマンドの画像検索を、非公式スクレイピングの DuckDuckGo（`ddgs`）から Bing Image Search API（Azure Cognitive Services）へ移行します。

## 変更内容
- `api.py`: `API.image_search()` を追加し、Bing Image Search API v7（`Ocp-Apim-Subscription-Key` ヘッダー使用）を呼び出す実装を追加
- `main.py`: `/image` コマンドを `API.image_search()` 経由に変更し、`ddgs`（`from ddgs import DDGS`）への依存を削除
- `requirements.txt` から `ddgs` を削除
- `.env.example` / `README.md` に `BING_IMAGE_SEARCH_API_KEY`（オプション）の説明を追加
- README のコマンド一覧表に抜けていた `/image` を追加

## ⚠️ 事前準備が必要（マージ前にご確認ください）
このPRのマージ・デプロイには **Bing Image Search API キーの取得** が必要です。

### 取得方法
1. [Azure Portal](https://portal.azure.com/) にサインイン（アカウントがなければ作成）
2. リソースの作成 → **「Bing Search v7」** を検索して作成
   - 料金プランは無料枠（F1、月1,000リクエストまで）を選択可能
3. 作成後、リソースの「キーとエンドポイント」からキーを1つコピー
4. `.env` に以下を追加

```env
BING_IMAGE_SEARCH_API_KEY=取得したキー
```

キーが未設定の場合、`/image` コマンドは「画像検索機能が利用できません。」というエラーを返すのみで、Bot自体は問題なく起動します（`/search` の Perplexity 未設定時と同様のフォールバック挙動）。

## 関連Issue
Closes #34

## テスト
- [x] `python3 -m py_compile main.py api.py` で構文チェック済み
- [x] `ddgs` への参照が残っていないことを確認済み
- [ ] 実際の Bing API キーでの動作確認は未実施（キー未取得のため）


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHmEsFtSDWADeYdZVn4btc)_